### PR TITLE
ci: Fix package workflow failure with several errors

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -190,7 +190,8 @@ jobs:
           sudo incus exec target \
             --cwd /home/groonga-nginx \
             --user 1000 \
-            --group 1000 -- \
+            --group 1000 \
+            -- \
             /host/packages/${{ matrix.task-namespace }}/test.sh
           sudo incus stop target
           sudo incus delete target

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -187,7 +187,10 @@ jobs:
           sudo incus exec target -- \
             sh -c "echo 'groonga-nginx ALL=(ALL:ALL) NOPASSWD:ALL' | \
                      EDITOR='tee -a' visudo -f /etc/sudoers.d/groonga-nginx-nopasswd"
-          sudo incus exec target --user 1000 --group 1000 -- \
+          sudo incus exec target \
+            --cwd /home/groonga-nginx \
+            --user 1000 \
+            --group 1000 -- \
             /host/packages/${{ matrix.task-namespace }}/test.sh
           sudo incus stop target
           sudo incus delete target

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -99,7 +99,7 @@ echo "::endgroup::"
 
 
 echo "::group::Connection test"
-sudo apt install -V -y jq curl
+sudo apt install -V -y curl jq
 curl http://localhost:10041/d/status | tee status.json
 groonga_version=$(jq -r '.[1].version' status.json)
 echo "::endgroup::"

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -67,7 +67,7 @@ sudo gpg \
   --import keys
 
 sudo apt install -V -y reprepro
-repositories_dir=/vagrant/packages/apt/repositories
+repositories_dir=/host/packages/apt/repositories
 pushd /tmp/
 mkdir -p conf/
 cat <<DISTRIBUTIONS > conf/distributions
@@ -99,7 +99,7 @@ echo "::endgroup::"
 
 
 echo "::group::Connection test"
-sudo apt install -V -y jq
+sudo apt install -V -y jq curl
 curl http://localhost:10041/d/status | tee status.json
 groonga_version=$(jq -r '.[1].version' status.json)
 echo "::endgroup::"


### PR DESCRIPTION
Errors:

```
+ wget https://apache.jfrog.io/artifactory/arrow/debian/apache-arrow-apt-source-latest-bookworm.deb
--2024-03-19 13:58:19--  https://apache.jfrog.io/artifactory/arrow/debian/apache-arrow-apt-source-latest-bookworm.deb
Resolving apache.jfrog.io (apache.jfrog.io)... 54.185.186.5, 100.21.156.46, 44.226.59.123
Connecting to apache.jfrog.io (apache.jfrog.io)|54.185.186.5|:443... connected.
HTTP request sent, awaiting response... 200
Length: 65920 (64K) [application/x-debian-package]
apache-arrow-apt-source-latest-bookworm.deb: Permission denied
```

```
+ reprepro includedeb bookworm '/vagrant/packages/apt/repositories/debian/pool/bookworm/main/*/*/*_amd64.deb'
Error 2 opening /vagrant/packages/apt/repositories/debian/pool/bookworm/main/*/*/*_amd64.deb: No such file or directory
```

```
+ curl http://localhost:10041/d/status
+ tee status.json
/host/packages/apt/test.sh: line 102: curl: command not found
```

It can now run up `::group::Test.`
`grntest` fails on this commit.  Additional modifications are needed to succeed.