### PR TITLE
ci package: checkout Apache Arrow source

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -83,9 +83,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
+      APACHE_ARROW_REPOSITORY: ${{ github.workspace }}/apache-arrow
       GROONGA_REPOSITORY: ${{ github.workspace }}/groonga
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          path: apache-arrow
+          repository: apache/arrow
       - uses: actions/checkout@v4
         with:
           repository: groonga/groonga


### PR DESCRIPTION
Because Groonga unvendored apache/arrow. We need to checkout apache/arrow manually to build .deb/.rpm packages.

ref: https://github.com/groonga/groonga/pull/1789