### PR TITLE
Update license of debian package to LGPL-2.1-or-later

### DIFF
--- a/packages/debian/copyright
+++ b/packages/debian/copyright
@@ -5,9 +5,9 @@ Source: https://packages.groonga.org/source/groonga-nginx/
 Files: *
 Copyright: 2012-2017  Brazil
            2018-2023  Sutou Kouhei <kou@clear-code.com>
-License: LGPL-2.1
+License: LGPL-2.1+
 
-License: LGPL-2.1
+License: LGPL-2.1+
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
  License as published by the Free Software Foundation; either


### PR DESCRIPTION
GitHub: GH-12

We got them to agree to the license change, and the license header was changed (8f46a91480ee927d0a7279b7d1bcf2899b6809bb),
but the update of this file was missing.