### PR TITLE
Update the license in readme to LGPL-2.1 or later

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,6 @@ location /d/ {
 
 ## License
 
-LGPLv2.1 only.
+LGPLv2.1 or later.
 
 See [COPYING](COPYING) for details.


### PR DESCRIPTION
GitHub: GH-12

We got them to agree to the license change, and the license header was changed (8f46a91480ee927d0a7279b7d1bcf2899b6809bb),
but the update of this file was missing.