### PR TITLE
packages ubuntu: support for Ubuntu 24.04

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -81,6 +81,9 @@ jobs:
           # - id: debian-bookworm-arm64
           #   task-namespace: apt
           #   test-image: "images:debian/12/arm64"
+          - id: ubuntu-noble-amd64
+            task-namespace: apt
+            test-image: "images:ubuntu/24.04"
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:

--- a/packages/apt/ubuntu-noble/Dockerfile
+++ b/packages/apt/ubuntu-noble/Dockerfile
@@ -1,0 +1,49 @@
+# Copyright (C) 2025  Kodama Takuya <kou@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+ARG FROM=ubuntu:noble
+FROM ${FROM}
+
+RUN \
+  echo "debconf debconf/frontend select Noninteractive" | \
+    debconf-set-selections
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
+  apt update ${quiet} && \
+  apt install -y -V ${quiet} \
+    ca-certificates \
+    lsb-release \
+    wget && \
+  wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
+  apt install -y -V ${quiet} ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
+  rm apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
+  wget https://packages.groonga.org/ubuntu/groonga-apt-source-latest-$(lsb_release --codename --short).deb && \
+  apt install -y -V ${quiet} ./groonga-apt-source-latest-$(lsb_release --codename --short).deb && \
+  rm groonga-apt-source-latest-$(lsb_release --codename --short).deb && \
+  apt update ${quiet} && \
+  apt install -y -V ${quiet} \
+    build-essential \
+    ccache \
+    debhelper \
+    devscripts \
+    lsb-release \
+    libgroonga-dev \
+    nginx-dev \
+    pkg-config && \
+  apt clean


### PR DESCRIPTION
We will release `groonga-nginx` package from packages.groonga.org.
This is the first step to support Ubuntu packages.