### PR TITLE
ci: Add `--quiet` option to `incus launch`

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -191,7 +191,7 @@ jobs:
       - name: Test
         run: |
           sudo incus admin init --auto
-          sudo incus launch ${{ matrix.test-image }} target
+          sudo incus --quiet launch ${{ matrix.test-image }} target
           sudo incus config device add target host disk source=$PWD path=/host
           sudo incus exec target -- adduser --uid 10000 groonga-nginx
           sudo incus exec target -- \


### PR DESCRIPTION
It is easier to see the logs if there is no progress log.

```
$ incus --help | grep quiet
  -q, --quiet          Don't show progress information
```