### PR TITLE
packages ubuntu: support for Ubuntu 24.04 arm64

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -62,6 +62,9 @@ jobs:
           - id: ubuntu-noble-amd64
             task-namespace: apt
             test-image: "images:ubuntu/24.04"
+          - id: ubuntu-noble-arm64
+            task-namespace: apt
+            test-image: "images:ubuntu/24.04/arm64"
     runs-on: >-
       ${{ contains(matrix.id, 'arm64') && 'ubuntu-24.04-arm' ||
                                           'ubuntu-latest' }}

--- a/packages/apt/ubuntu-noble-arm64/from
+++ b/packages/apt/ubuntu-noble-arm64/from
@@ -1,0 +1,17 @@
+# Copyright (C) 2025  Kodama Takuya <otegami@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--platform=linux/arm64 arm64v8/ubuntu:noble


### PR DESCRIPTION
We will release groonga-nginx package from packages.groonga.org.
This is the first step to support Ubuntu packages.