### PR TITLE
news: add 1.0.1 entry

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,11 +13,11 @@ dependency is different. The packages from packages.groonga.org include Groonga
 built with Apache Arrow enabled. Which unlocks extra features such as offline
 parallel index building.
 
-### Migration Notice for groonga-nginx
+### Migration Notice for groonga-nginx (Ubuntu Users Only)
 
-If you're currently using groonga-nginx, we recommend migrating to the packages
-provided by groonga.packages.org. Although the Groonga APT repository will still
-be available, it will no longer receive new updates in near future.
+If you're currently using groonga-nginx on Ubuntu, we recommend migrating to the
+packages provided by groonga.packages.org. Although the Groonga APT repository
+will still be available, it will no longer receive new updates in near future.
 
 For migration, please follow these steps:
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,14 +4,14 @@
 
 ### Package distribution update
 
-In previous releases, Ubuntu packages were available only through the Groonga
-APT repository. Starting with this release, packages are also distributed via
-packages.groonga.org.
+In previous releases, Ubuntu packages were available only through
+https://launchpad.net/~groonga/+archive/ubuntu/ppa. Starting with this release,
+packages are also distributed via https://packages.groonga.org/.
 
 While the groonga-nginx package itself remains unchanged, the underlying Groonga
-dependency is different. The packages from packages.groonga.org include Groonga
-built with Apache Arrow enabled. Which unlocks extra features such as offline
-parallel index building.
+dependency is different. The packages from https://packages.groonga.org/ include
+Groonga built with Apache Arrow enabled. Which unlocks extra features such as
+offline parallel index building.
 
 ### Migration Notice for groonga-nginx (Ubuntu Users Only)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,7 +26,7 @@ $ wget https://packages.groonga.org/$(lsb_release --id --short | tr 'A-Z' 'a-z')
 $ sudo apt install -y -V ./groonga-apt-source-latest-$(lsb_release --codename --short).deb
 $ rm -f groonga-apt-source-latest-$(lsb_release --codename --short).deb
 $ sudo apt update
-$ sudo apt update -y -V libnginx-mod-http-groonga
+$ sudo apt install -y -V libnginx-mod-http-groonga
 ```
 
 ## 1.0.0 - 2023-07-21

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,16 +2,16 @@
 
 ## 1.0.1 - 2025-02-21
 
-### Package distribution update
+### Package Distribution Update
 
-In previous releases, Ubuntu packages were available only through
-https://launchpad.net/~groonga/+archive/ubuntu/ppa. Starting with this release,
-packages are also distributed via https://packages.groonga.org/.
+In previous releases, Ubuntu packages were available only through the PPA on
+Launchpad(ppa:groonga/ppa). Starting with this release, packages are also
+distributed via our Groonga APT repository at https://packages.groonga.org.
 
 While the groonga-nginx package itself remains unchanged, the underlying Groonga
-dependency is different. The packages from https://packages.groonga.org/ include
-Groonga built with Apache Arrow enabled. Which unlocks extra features such as
-offline parallel index building.
+dependency is different. Packages from our Groonga APT repository
+(https://packages.groonga.org/) include Groonga built with Apache Arrow enabled,
+which unlocks extra features such as offline parallel index building.
 
 ### Migration Notice for groonga-nginx (Ubuntu Users Only)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,34 @@
 # NEWS
 
+## 1.0.1 - 2025-02-21
+
+### Package distribution update
+
+In previous releases, Ubuntu packages were available only through the Groonga
+APT repository. Starting with this release, packages are also distributed via
+packages.groonga.org.
+
+### Migration Notice for groonga-nginx
+
+If you’re currently using groonga-nginx, we recommend migrating to the packages
+provided by groonga.packages.org. Although the Groonga APT repository will still
+be available, it will no longer receive new updates in near future.
+
+For migration, please follow these steps:
+
+```console
+$ sudo add-apt-repository --remove ppa:groonga/ppa
+$ sudo apt install -y -V ca-certificates lsb-release wget
+$ wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+$ sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+$ rm -f apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+$ wget https://packages.groonga.org/debian/groonga-apt-source-latest-$(lsb_release --codename --short).deb
+$ sudo apt install -y -V ./groonga-apt-source-latest-$(lsb_release --codename --short).deb
+$ rm -f groonga-apt-source-latest-$(lsb_release --codename --short).deb
+$ sudo apt update
+$ sudo apt update -y -V libnginx-mod-http-groonga
+```
+
 ## 1.0.0 - 2023-07-21
 
 Initial release!

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@ packages.groonga.org.
 
 While the groonga-nginx package itself remains unchanged, the underlying Groonga
 dependency is different. The packages from packages.groonga.org include Groonga
-built with Apache Arrow enabled. Which unlocks extra features such as static
+built with Apache Arrow enabled. Which unlocks extra features such as offline
 parallel index building.
 
 ### Migration Notice for groonga-nginx

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,7 +22,7 @@ $ sudo apt install -y -V ca-certificates lsb-release wget
 $ wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
 $ sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
 $ rm -f apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-$ wget https://packages.groonga.org/debian/groonga-apt-source-latest-$(lsb_release --codename --short).deb
+$ wget https://packages.groonga.org/$(lsb_release --id --short | tr 'A-Z' 'a-z')/groonga-apt-source-latest-$(lsb_release --codename --short).deb
 $ sudo apt install -y -V ./groonga-apt-source-latest-$(lsb_release --codename --short).deb
 $ rm -f groonga-apt-source-latest-$(lsb_release --codename --short).deb
 $ sudo apt update

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,11 @@ In previous releases, Ubuntu packages were available only through the Groonga
 APT repository. Starting with this release, packages are also distributed via
 packages.groonga.org.
 
+While the groonga-nginx package itself remains unchanged, the underlying Groonga
+dependency is different. The packages from packages.groonga.org include Groonga
+built with Apache Arrow enabled. Which unlocks extra features such as static
+parallel index building.
+
 ### Migration Notice for groonga-nginx
 
 If you’re currently using groonga-nginx, we recommend migrating to the packages

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,7 @@ parallel index building.
 
 ### Migration Notice for groonga-nginx
 
-If you’re currently using groonga-nginx, we recommend migrating to the packages
+If you're currently using groonga-nginx, we recommend migrating to the packages
 provided by groonga.packages.org. Although the Groonga APT repository will still
 be available, it will no longer receive new updates in near future.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # NEWS
 
-## 1.0.1 - 2025-02-21
+## 1.0.1 - 2025-02-25
 
 ### Package Distribution Update
 
@@ -13,26 +13,7 @@ dependency is different. Packages from our Groonga APT repository
 (https://packages.groonga.org/) include Groonga built with Apache Arrow enabled,
 which unlocks extra features such as offline parallel index building.
 
-### Migration Notice for groonga-nginx (Ubuntu Users Only)
-
-If you're currently using groonga-nginx on Ubuntu, we recommend migrating to the
-packages provided by groonga.packages.org. Although the Groonga APT repository
-will still be available, it will no longer receive new updates in near future.
-
-For migration, please follow these steps:
-
-```console
-$ sudo add-apt-repository --remove ppa:groonga/ppa
-$ sudo apt install -y -V ca-certificates lsb-release wget
-$ wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-$ sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-$ rm -f apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-$ wget https://packages.groonga.org/$(lsb_release --id --short | tr 'A-Z' 'a-z')/groonga-apt-source-latest-$(lsb_release --codename --short).deb
-$ sudo apt install -y -V ./groonga-apt-source-latest-$(lsb_release --codename --short).deb
-$ rm -f groonga-apt-source-latest-$(lsb_release --codename --short).deb
-$ sudo apt update
-$ sudo apt install -y -V libnginx-mod-http-groonga
-```
+We will announce how to use Groonga APT repository soon.
 
 ## 1.0.0 - 2023-07-21
 

--- a/README.md
+++ b/README.md
@@ -7,28 +7,17 @@ This was formerly distributed with Groonga and provided as `groonga-httpd` with 
 ## Install
 
 Debian GNU/Linux bookworm or later:
+Ubuntu 24.04 or later:
 
 ```console
 $ sudo apt install -y -V ca-certificates lsb-release wget
 $ wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
 $ sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
 $ rm -f apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-$ wget https://packages.groonga.org/debian/groonga-apt-source-latest-$(lsb_release --codename --short).deb
+$ wget https://packages.groonga.org/$(lsb_release --id --short | tr 'A-Z' 'a-z')/groonga-apt-source-latest-$(lsb_release --codename --short).deb
 $ sudo apt install -y -V ./groonga-apt-source-latest-$(lsb_release --codename --short).deb
 $ rm -f groonga-apt-source-latest-$(lsb_release --codename --short).deb
 $ sudo apt update
-$ sudo apt install -y -V libnginx-mod-http-groonga
-$ sudo cp /etc/nginx/groonga.conf /etc/nginx/conf.d/
-$ sudo editor /etc/nginx/conf.d/groonga.conf
-$ sudo systemctl restart nginx
-```
-
-Ubuntu 23.10 or later:
-
-```console
-$ sudo apt -y -V install software-properties-common
-$ sudo add-apt-repository -y universe
-$ sudo add-apt-repository -y ppa:groonga/ppa
 $ sudo apt install -y -V libnginx-mod-http-groonga
 $ sudo cp /etc/nginx/groonga.conf /etc/nginx/conf.d/
 $ sudo editor /etc/nginx/conf.d/groonga.conf

--- a/README.md
+++ b/README.md
@@ -7,17 +7,28 @@ This was formerly distributed with Groonga and provided as `groonga-httpd` with 
 ## Install
 
 Debian GNU/Linux bookworm or later:
-Ubuntu 24.04 or later:
 
 ```console
 $ sudo apt install -y -V ca-certificates lsb-release wget
 $ wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
 $ sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
 $ rm -f apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-$ wget https://packages.groonga.org/$(lsb_release --id --short | tr 'A-Z' 'a-z')/groonga-apt-source-latest-$(lsb_release --codename --short).deb
+$ wget https://packages.groonga.org/debian/groonga-apt-source-latest-$(lsb_release --codename --short).deb
 $ sudo apt install -y -V ./groonga-apt-source-latest-$(lsb_release --codename --short).deb
 $ rm -f groonga-apt-source-latest-$(lsb_release --codename --short).deb
 $ sudo apt update
+$ sudo apt install -y -V libnginx-mod-http-groonga
+$ sudo cp /etc/nginx/groonga.conf /etc/nginx/conf.d/
+$ sudo editor /etc/nginx/conf.d/groonga.conf
+$ sudo systemctl restart nginx
+```
+
+Ubuntu 23.10 or later:
+
+```console
+$ sudo apt -y -V install software-properties-common
+$ sudo add-apt-repository -y universe
+$ sudo add-apt-repository -y ppa:groonga/ppa
 $ sudo apt install -y -V libnginx-mod-http-groonga
 $ sudo cp /etc/nginx/groonga.conf /etc/nginx/conf.d/
 $ sudo editor /etc/nginx/conf.d/groonga.conf


### PR DESCRIPTION
The migration process is still being worked out.
We only announce that we have placed it in package.groonga.org at this time.