### PR TITLE
ci release: fix wrong artifacts path

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -225,7 +225,6 @@ jobs:
         with:
           path: release-artifacts
           pattern: release-*
-          merge-multiple: true
       - name: Extract release note
         run: |
           ruby \


### PR DESCRIPTION
In our previous release, the process failed with the following error because the artifact path did not match our expectations.
This change adjusts the configuration by removing the `merge-multiple: true` option.
Which ensures that the release artifacts are placed in the correct directory structure. 

```
Run title="$(head -n1 release-note.md | sed -e 's/^## //')"
  title="$(head -n1 release-note.md | sed -e 's/^## //')"
  tail -n +2 release-note.md > release-note-without-version.md
  gh release create ${GITHUB_REF_NAME} \
    --discussion-category Announcements \
    --notes-file release-note-without-version.md \
    --title "${title}" \
    release-artifacts/*/*
  shell: /usr/bin/bash -e {0}
  env:
    GH_TOKEN: ***
stat release-artifacts/*/*: no such file or directory
```

ref: https://github.com/groonga/groonga-nginx/actions/runs/13512220684/job/37755028715