### PR TITLE
ci: Utilize `rubygems-requirements-system`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -117,6 +117,7 @@ jobs:
         if:
           matrix.groonga-version == 'main'
         run: |
+          sudo gem install rubygems-requirements-system
           sudo env MAKEFLAGS=-j$(nproc) gem install \
             grntest \
             pkg-config \

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -102,17 +102,6 @@ jobs:
             --prefix=/tmp/local
           make -j$(nproc)
           make install
-      - name: Enable Apache Arrow repository
-        if:
-          matrix.groonga-version == 'main'
-        run: |
-          sudo apt update -o="APT::Acquire::Retries=3"
-          sudo apt install -y -V -o="APT::Acquire::Retries=3" \
-            lsb-release \
-            wget
-          wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-          sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-          sudo apt update -o="APT::Acquire::Retries=3"
       - name: Install test dependencies
         if:
           matrix.groonga-version == 'main'


### PR DESCRIPTION
Fix the following error:

```
extconf.rb:42:in `<main>': Apache Arrow C++ >= 21 isn't found. (RuntimeError)
You can install it automatically by enabling rubygems-requirements-system.
See https://github.com/ruby-gnome/rubygems-requirements-system/ how to enable it.
```

Apache Arrow repository is installed by grntest and rubygems-requirements-system.